### PR TITLE
feat!(doom): replace ivy with vertico

### DIFF
--- a/docker/doom/configs/init.el
+++ b/docker/doom/configs/init.el
@@ -7,7 +7,7 @@
 
 (doom! :completion
        company           ; the ultimate code completion backend
-       ivy               ; a search engine for love and life
+       vertico           ; the search engine of the future
 
        :ui
        doom              ; what makes DOOM look the way it does


### PR DESCRIPTION
Vertico is Doom's new default, so it makes sense to replace ivy here.

Also secretly hoping to trigger a Docker rebuild for the Doom image, as
it seems broken (doesn't have the correct cloned files in /home/gitpod/.emacs.d)