### PR TITLE
Run doom installation cmd from final location

### DIFF
--- a/docker/default/Dockerfile
+++ b/docker/default/Dockerfile
@@ -10,7 +10,7 @@ RUN mv .emacs.d vanilla
 COPY .emacs-profiles.el /home/gitpod/.emacs-profiles.el
 RUN git clone --depth 1 https://github.com/plexus/chemacs2 /home/gitpod/.emacs.d/
 
-COPY --from=yyoncho/gitpod-doom:1.0.0 /home/gitpod/.emacs.d /home/gitpod/doom
+COPY --from=yyoncho/gitpod-doom:1.0.0 /home/gitpod/doom /home/gitpod/doom
 
 COPY --from=yyoncho/gitpod-spacemacs:1.0.12 /home/gitpod/.emacs.d /home/gitpod/spacemacs
 COPY --from=yyoncho/gitpod-spacemacs:1.0.12 /home/gitpod/.spacemacs.d /home/gitpod/.spacemacs.d

--- a/docker/doom/Dockerfile
+++ b/docker/doom/Dockerfile
@@ -6,9 +6,9 @@ RUN rm -rf ~/.emacs.d
 # Doom
 ## Clone and set the DOOMDIR folder
 
-RUN git clone --depth 1 https://github.com/hlissner/doom-emacs /home/gitpod/.emacs.d/ --branch develop
+RUN git clone --depth 1 https://github.com/hlissner/doom-emacs /home/gitpod/doom/ --branch develop
 COPY configs /home/gitpod/.config/doom
 
 ## Sync to install modules and packages
 RUN ulimit -n 9000
-RUN EMACS=~/emacs/src/emacs ~/.emacs.d/bin/doom sync
+RUN EMACS=~/emacs/src/emacs ~/doom/bin/doom sync


### PR DESCRIPTION
Doom needs to run the `sync` from the location where you want it to run,
so using `.emacs.d` in doom Dockerfile before moving everything to
`doom` will fail